### PR TITLE
Add has_route_plan filter to route_visit resource

### DIFF
--- a/app/models/route_visit.rb
+++ b/app/models/route_visit.rb
@@ -32,4 +32,8 @@ class RouteVisit < ActiveRecord::Base
 			.flat_map {|f| f.order}
 			.any? {|o| o.purchase_order?}
 	end
+
+	def has_route_plan?
+		has_route_plan.present?
+	end
 end

--- a/app/resources/route_visit_resource.rb
+++ b/app/resources/route_visit_resource.rb
@@ -6,19 +6,27 @@ class RouteVisitResource < JSONAPI::Resource
               :route_visit_state,
               :completed_at
 
-  attribute :fulfillment_count
-  attribute  :has_pickup
-  attribute  :has_drop
+  attribute   :fulfillment_count
+  attribute   :has_pickup
+  attribute   :has_drop
 
-  has_one :route_plan
-  has_one :address
+  has_one     :route_plan
+  has_one     :address
 
-  has_many  :fulfillments
+  has_many    :fulfillments
 
-  filter    :date
+  filter      :date
 
   filter :status, default: 'with_valid_orders', apply: ->(records, value, _options) {
     records.joins(orders: :order_items).where('order_items.quantity > ?', 0).distinct
+  }
+
+  filter :has_route_plan, apply: ->(records, value, _options) {
+    if value
+      records.where(route_plan_id: nil)
+    else
+      records.where.not(route_plan_id: nil)
+    end
   }
 
   def records_for_fulfillments
@@ -36,5 +44,4 @@ class RouteVisitResource < JSONAPI::Resource
   def has_drop
     @model.fulfillments.any? {|f| f.order.purchase_order?}
   end
-
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ admin = User.create(first_name:'Tony', last_name:'Starks', email:'admin@wutang.c
 admin.set_admin_role!
 admin.save
 
-FactoryGirl.create_list(:item, 10, tag: Item::PRODUCT_TYPE)
+FactoryGirl.create_list(:item, 10, tag: Item::PRODUCT_TYPE, is_sold: true, is_purchased: false)
 
 FactoryGirl.create_list(:price_tier, 3, items: Item.products)
 


### PR DESCRIPTION
1. You can now filter on route_visit resources by `has_route_plan`
2. Seeds now correctly creates products with is_sold and is_product